### PR TITLE
Remove deprecated aws-sdk-go dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/EppO/terraform-provider-environment
 go 1.25.8
 
 require (
-	github.com/aws/aws-sdk-go v1.55.6
 	github.com/hashicorp/go-uuid v1.0.3
 	github.com/hashicorp/terraform-plugin-docs v0.25.0
 	github.com/hashicorp/terraform-plugin-sdk/v2 v2.40.1

--- a/go.sum
+++ b/go.sum
@@ -21,8 +21,6 @@ github.com/apparentlymart/go-textseg/v15 v15.0.0 h1:uYvfpb3DyLSCGWnctWKGj857c6ew
 github.com/apparentlymart/go-textseg/v15 v15.0.0/go.mod h1:K8XmNZdhEBkdlyDdvbmmsvpAG721bKi0joRfFdHIWJ4=
 github.com/armon/go-radix v1.0.0 h1:F4z6KzEeeQIMeLFa97iZU6vupzoecKdU5TX24SNppXI=
 github.com/armon/go-radix v1.0.0/go.mod h1:ufUuZ+zHj4x4TnLV4JWEpy2hxWSpsRywHrMgIH9cCH8=
-github.com/aws/aws-sdk-go v1.55.6 h1:cSg4pvZ3m8dgYcgqB97MrcdjUmZ1BeMYKUxMMB89IPk=
-github.com/aws/aws-sdk-go v1.55.6/go.mod h1:eRwEWoyTWFMVYVQzKMNHWP5/RV4xIUGMQfXQHfHkpNU=
 github.com/bgentry/speakeasy v0.1.0 h1:ByYyxL9InA1OWqxJqqp2A5pYHUrCiAL6K3J+LKSsQkY=
 github.com/bgentry/speakeasy v0.1.0/go.mod h1:+zsyZBPWlz7T6j88CTgSN5bM796AkVf0kBD4zp0CCIs=
 github.com/bmatcuk/doublestar/v4 v4.10.0 h1:zU9WiOla1YA122oLM6i4EXvGW62DvKZVxIe6TYWexEs=
@@ -131,8 +129,6 @@ github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99 h1:BQSFePA1RWJOl
 github.com/jbenet/go-context v0.0.0-20150711004518-d14ea06fba99/go.mod h1:1lJo3i6rXxKeerYnT8Nvf0QmHCRC1n8sfWVwXF2Frvo=
 github.com/jhump/protoreflect v1.17.0 h1:qOEr613fac2lOuTgWN4tPAtLL7fUSbuJL5X5XumQh94=
 github.com/jhump/protoreflect v1.17.0/go.mod h1:h9+vUUL38jiBzck8ck+6G/aeMX8Z4QUY/NiJPwPNi+8=
-github.com/jmespath/go-jmespath v0.4.0 h1:BEgLn5cpjn8UN1mAw4NjwDrS35OdebyEtFe+9YPoQUg=
-github.com/jmespath/go-jmespath v0.4.0/go.mod h1:T8mJZnbsbmF+m6zOOFylbeCJqk5+pHWvzYPziyZiYoo=
 github.com/kevinburke/ssh_config v1.2.0 h1:x584FjTGwHzMwvHx18PXxbBVzfnxogHaAReU4gf13a4=
 github.com/kevinburke/ssh_config v1.2.0/go.mod h1:CT57kijsi8u/K/BOFA39wgDQJ9CxiF4nAY/ojJ6r6mM=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=

--- a/internal/provider/data_source_variables.go
+++ b/internal/provider/data_source_variables.go
@@ -8,7 +8,6 @@ import (
 
 	"encoding/base64"
 
-	"github.com/aws/aws-sdk-go/aws"
 	"github.com/hashicorp/go-uuid"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/diag"
 	"github.com/hashicorp/terraform-plugin-sdk/v2/helper/schema"
@@ -21,7 +20,7 @@ func dataSourceVariables() *schema.Resource {
 			"sensitive": {
 				Type:     schema.TypeBool,
 				Optional: true,
-				Default:  aws.Bool(false),
+				Default:  false,
 			},
 			"filter": {
 				Type:     schema.TypeString,


### PR DESCRIPTION
## Summary

`github.com/aws/aws-sdk-go` (v1) was pulled in for a **single** `aws.Bool(false)` call — the default value of the `sensitive` attribute on the `environment_variables` data source. AWS [ended support for aws-sdk-go v1 on 2025-07-31](https://aws.amazon.com/blogs/developer/announcing-end-of-support-for-aws-sdk-for-go-v1-on-july-31-2025/), and recent releases annotate the packages as deprecated. With the golangci-lint v2 upgrade now in place, staticcheck's `SA1019` flags the import and fails the `Build` (lint) job — see PR #555.

## Change

- Replace `aws.Bool(false)` with a plain `false` and drop the `aws-sdk-go` import.
- `go mod tidy` removes `aws-sdk-go` and its only transitive dependency (`jmespath`) from `go.mod`/`go.sum`.

A `TypeBool` schema's `Default` expects a `bool`, not the `*bool` that `aws.Bool` returns, so this is also a minor correctness improvement (the old value only worked due to lenient `mapstructure` decoding in the config read path).

## Audit

Exhaustive sweep confirmed this was the only usage:
- 1 import, 1 `aws.*` call — both in `internal/provider/data_source_variables.go`
- No test/example/tool usage; no `aws-sdk-go-v2`
- Nothing else depends on it transitively (`go mod why` / `go mod graph`)

## Verification

`go build`, `go vet`, `go generate ./...` (no diff), and `golangci-lint run` (0 issues) all pass locally.

Supersedes dependabot PR #555 (which bumped the now-removed v1 SDK and can be closed).
