### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -5,6 +5,9 @@ on:
   pull_request:
     branches: [ $default-branch ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/EppO/terraform-provider-environment/security/code-scanning/3](https://github.com/EppO/terraform-provider-environment/security/code-scanning/3)

Add an explicit `permissions` block to `.github/workflows/go.yml` at the workflow root (top-level), so it applies to all jobs unless overridden. For this CI workflow, the minimal required permission is:

- `contents: read`

Best single fix without changing functionality:
- Insert `permissions:` between the `on:` trigger block and `jobs:`.
- Set only `contents: read`, which is sufficient for checkout/build/test in this snippet and aligns with CodeQL’s suggested baseline.

No imports, methods, or dependencies are needed (YAML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
