### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,8 @@ on:
   push:
     tags:
       - 'v*'
+permissions:
+  contents: write
 jobs:
   goreleaser:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/EppO/terraform-provider-environment/security/code-scanning/1](https://github.com/EppO/terraform-provider-environment/security/code-scanning/1)

Add an explicit `permissions` block in `.github/workflows/release.yml` to avoid inheriting potentially broad defaults and to document required token scope.  
Best fix without changing intended functionality: define workflow-level permissions right after `on:` with the minimum needed for this release job.

Because this workflow runs GoReleaser to publish releases on tag push, it typically needs write access to repository contents (to create/update GitHub Releases). So set:

- `contents: write`

This is safer than implicit broad defaults and still preserves release behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
