### PR TITLE
Bump GitHub Actions off deprecated Node 20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,15 +35,15 @@ jobs:
       -
         name: Import GPG key
         id: import_gpg
-        uses: crazy-max/ghaction-import-gpg@v6
+        uses: crazy-max/ghaction-import-gpg@v7
         with:
           gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
           passphrase: ${{ secrets.PASSPHRASE }}
       -
         name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
-          version: latest
+          version: '~> v2'
           args: release --clean
         env:
           GPG_FINGERPRINT: ${{ steps.import_gpg.outputs.fingerprint }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,7 +68,7 @@ jobs:
         with:
           go-version-file: 'go.mod'
           cache: true
-      - uses: hashicorp/setup-terraform@v3
+      - uses: hashicorp/setup-terraform@v4
         with:
           terraform_version: ${{ matrix.terraform }}
           terraform_wrapper: false


### PR DESCRIPTION
## Summary

CI emits deprecation warnings because several actions still run on Node.js 20:

> Node.js 20 actions are deprecated. [...] Actions will be forced to run with Node.js 24 by default starting June 16th, 2026.

This bumps each to a Node.js 24 release:

| Action | Before | After |
|---|---|---|
| `hashicorp/setup-terraform` | v3 | v4 |
| `crazy-max/ghaction-import-gpg` | v6 | v7 |
| `goreleaser/goreleaser-action` | v6 | v7 |

All action inputs are unchanged, so these are drop-in updates. The v7 actions require Actions Runner v2.327.1+, which GitHub-hosted runners already satisfy.

Also pins GoReleaser to `~> v2` (was `latest`) to avoid an unintended jump to a future v3 major, per the action's own warning.